### PR TITLE
Update ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,7 +3,7 @@
 - Fixes to office comparison
 - Documentation improvements
 - Improvements to Windows support (Volker Paulsen)
-- Improvements to MacOSX support (Scott Prahl)
+- Improvements to Mac OS X support (Scott Prahl)
 - Improvements to FreeBSD support (Peter)
 - Fix for random segfaults with OpenOffice/LibreOffice (Volker Paulsen)
 - Reliability check for unoconv listener (Volker Paulsen)
@@ -23,7 +23,7 @@
 - Show Office location when using -v -v
 - Fix a problem when not using UNO_PATH and LibreOffice (Daniel Díaz)
 - Improvements to Windows support (Miklos Vajna)
-- Improvements to MacOS X support (Troels Knak-Nielsen)
+- Improvements to Mac OS X support (Troels Knak-Nielsen)
 - Improvements to OpenBSD support
 - Improvements to Gentoo support (David E. Narváez)
 - Added -n/--no-launch option to prevent lanuching new office instance (Alexander Oryol)


### PR DESCRIPTION
Fixed spelling of 'Mac OS X'.